### PR TITLE
Fix: Ensure authentication spinner is centered

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body, #__next {
+  height: 100%;
+}
+
 body {
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
@@ -178,6 +182,6 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-y-auto;
   }
 }


### PR DESCRIPTION
The main authentication loading spinner was reported as not being centered.

This commit addresses the issue by:
1. Modifying `src/app/globals.css` to ensure `html`, `body`, and the Next.js root element (`#__next`) have `height: 100%`. This provides a stable full-height context for elements using `h-screen`.
2. Adding `overflow-y: auto` to the `body` to ensure scrollability if content ever overflows, while maintaining the full height.
3. Verified that the spinner container in `src/components/architech-app.tsx` correctly uses the Tailwind CSS classes `flex h-screen items-center justify-center`, which are designed for centering.

These changes should ensure the full-page spinner displayed during initial authentication checks is properly centered on the viewport.